### PR TITLE
ci: assign reviewers on new PRs

### DIFF
--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -1,0 +1,37 @@
+---
+name: Assign reviewers
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'locales/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # for checkout
+
+jobs:
+  assign:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: 20
+      - run: corepack enable && pnpm --version
+      - run: pnpm install --loglevel=error --ignore-scripts
+      - run: |
+          pnpm run ci:assign-reviewers
+        env:
+          PR_NUMBER: ${{ github.event.number }}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "check:lint": "eslint .",
     "check:missing": "tsx src/cli/listMissingResources",
     "check:types": "tsc --noEmit",
+    "ci:assign-reviewers": "tsx src/cli/assignReviewers",
     "clean": "rimraf apps/studio/dist locales/*/dist",
     "dev": "SANITY_STUDIO_DEBUG_I18N=log turbo run dev",
     "format": "prettier --write .",

--- a/src/api/reviewers.ts
+++ b/src/api/reviewers.ts
@@ -1,0 +1,103 @@
+import {execFile as execFileCb} from 'node:child_process'
+import {promisify} from 'node:util'
+import {getRootPath} from '../util/getRootPath'
+import {getLocaleRegistry} from './registry'
+
+const execFile = promisify(execFileCb)
+const SANITY_REVIEWER = 'sanity-io/locales-reviewers'
+
+/**
+ * An object containing resolved reviewers
+ *
+ * @internal
+ */
+export interface Reviewers {
+  /**
+   * All reviewers, eg regardless of which locale they are reviewers _of_
+   */
+  all: Set<string>
+
+  /**
+   * Reviewers by locale, eg which reviewers are applicable for which locale
+   */
+  byLocale: Map<string, Set<string>>
+}
+
+/**
+ * Uses the currently checked out branch and gets the diffs from origin/main,
+ * then figures out which reviewers are applicable for the changes.
+ *
+ * @returns A promise that resolves to an object that contains reviewers
+ */
+export async function getReviewersFromBranchDiff(): Promise<Reviewers> {
+  const rootPath = await getRootPath()
+  const locales = await getLocaleRegistry()
+  const execGitCommand = (args: string[]) => execFile('git', args, {cwd: rootPath})
+
+  const {stdout: currentBranch} = await execGitCommand(['branch', '--show-current'])
+
+  const range = `origin/main...${currentBranch.trim()}`
+  const {stdout: fileDiffs} = await execGitCommand([
+    '--no-pager',
+    'diff',
+    '--name-only',
+    `${range}`,
+  ])
+
+  const changedFiles = fileDiffs.trim().split('\n')
+  const localeDiffs = new Set(
+    changedFiles.filter((file) => file.startsWith('locales/')).map((file) => file.split('/')[1]),
+  )
+
+  // Find locales corresponding to the changed files
+  const reviewers = new Set<string>()
+  const byLocale = new Map<string, Set<string>>()
+  for (const localeId of localeDiffs) {
+    const localeReviewers = byLocale.get(localeId) || new Set<string>()
+    byLocale.set(localeId, localeReviewers)
+
+    const locale = locales.find((candidate) => candidate.id === localeId)
+    if (!locale) {
+      // New locale, add Sanity team as reviewer
+      localeReviewers.add(SANITY_REVIEWER)
+      continue
+    }
+
+    // Add all maintainers of the locale as reviewers
+    for (const maintainer of locale.maintainers) {
+      reviewers.add(maintainer)
+      localeReviewers.add(maintainer)
+    }
+  }
+
+  // If we have no reviewers at all, add Sanity team as reviewer
+  if (reviewers.size === 0) {
+    reviewers.add(SANITY_REVIEWER)
+  }
+
+  return {
+    all: reviewers,
+    byLocale,
+  }
+}
+
+/**
+ * Assigns reviewers to the given PR, based on the currently checked out branch.
+ * There is no guarantee that the PR and the branch in question matches, so treat with caution.
+ *
+ * @param prNumber - The PR number to add reviewers to
+ * @returns A promise that resolves to the assigned reviewers
+ * @internal
+ */
+export async function assignReviewers(prNumber: number): Promise<Reviewers['all']> {
+  const rootPath = await getRootPath()
+  const {all: reviewers} = await getReviewersFromBranchDiff()
+
+  await execFile(
+    'gh',
+    ['pr', 'edit', `${prNumber}`, '--add-reviewer', Array.from(reviewers).join(',')],
+    {cwd: rootPath},
+  )
+
+  return reviewers
+}

--- a/src/cli/.eslintrc
+++ b/src/cli/.eslintrc
@@ -1,5 +1,6 @@
 {
   "rules": {
-    "no-console": "off"
+    "no-console": "off",
+    "no-process-env": "off"
   }
 }

--- a/src/cli/assignReviewers.ts
+++ b/src/cli/assignReviewers.ts
@@ -1,0 +1,9 @@
+import {assignReviewers} from '../api/reviewers'
+import {runScript} from '../util/runScript'
+
+const PR_NUMBER = parseInt((process.env.PR_NUMBER || '').trim(), 10)
+if (!PR_NUMBER || PR_NUMBER <= 0 || isNaN(PR_NUMBER)) {
+  throw new Error('PR_NUMBER environment variable is required')
+}
+
+runScript(() => assignReviewers(PR_NUMBER))


### PR DESCRIPTION
Introduces a new CI workflow that finds the changed files from a PR and assign reviewers based on them, from the locale registry. If no reviewers are found (eg on locales without a maintainer), it will tag the sanity-io/locales-reviewers team.
