### PR TITLE
feat: tag maintainers in body when opening PRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build": "turbo run build",
     "build:packages": "tsx src/cli/reconcilePackages",
     "build:studio": "tsx src/cli/reconcileStudio",
+    "list:maintainers": "tsx src/cli/printMaintainers",
     "check": "npm run check:lint && npm run check:types",
     "check:lint": "eslint .",
     "check:missing": "tsx src/cli/listMissingResources",

--- a/src/api/autoTranslate.ts
+++ b/src/api/autoTranslate.ts
@@ -247,6 +247,11 @@ export async function pushChanges(): Promise<void> {
     await execGitCommand(['push', 'origin', branchName, '--force'])
 
     if (!(await hasExistingPR(branchName))) {
+      let body = `This PR includes automated translation updates.`
+      if (locale.maintainers.length > 0) {
+        const maintainers = locale.maintainers.map((maintainer) => `@${maintainer}`)
+        body += `\n\nCC: ${maintainers.join(', ')}`
+      }
       // Now create the PR 🎉
       await execFile(
         'gh',
@@ -256,7 +261,7 @@ export async function pushChanges(): Promise<void> {
           '--title',
           commitMessage,
           '--body',
-          'This PR includes automated translation updates.',
+          body,
           '--head',
           branchName,
           '--base',

--- a/src/api/printMaintainers.ts
+++ b/src/api/printMaintainers.ts
@@ -1,0 +1,8 @@
+import registry from '../../locales/registry'
+
+export const printMaintainers = async () => {
+  registry.filter((locale) => locale.maintainers.length > 0).forEach((locale) => {
+    // eslint-disable-next-line no-console
+    console.log(`${locale.englishName}:`, locale.maintainers.join(', '))
+  })
+}

--- a/src/cli/printMaintainers.ts
+++ b/src/cli/printMaintainers.ts
@@ -1,0 +1,4 @@
+import { printMaintainers } from "../api/printMaintainers";
+import { runScript } from "../util/runScript";
+
+runScript(printMaintainers)


### PR DESCRIPTION
Since we cannot rely on CODEOWNERS in this repo suggest we automatically tag maintainers in the PR body text