### PR TITLE
ci: create explicit token with ecospark, declare permissions

### DIFF
--- a/.github/workflows/ai-translate.yml
+++ b/.github/workflows/ai-translate.yml
@@ -11,8 +11,6 @@ permissions:
 
 jobs:
   translate-and-pr:
-    permissions:
-      contents: write # for push
     runs-on: ubuntu-latest
     steps:
       - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2

--- a/.github/workflows/ai-translate.yml
+++ b/.github/workflows/ai-translate.yml
@@ -6,10 +6,21 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read # for checkout
+
 jobs:
   translate-and-pr:
+    permissions:
+      contents: write # for push
     runs-on: ubuntu-latest
     steps:
+      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        id: generate-token
+        with:
+          app_id: ${{ secrets.ECOSPARK_APP_ID }}
+          private_key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+
       - name: Check out repository
         uses: actions/checkout@v4
 
@@ -36,4 +47,4 @@ jobs:
         run: pnpm run autotranslate --git
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Uses a generated token instead of `GITHUB_TOKEN`. Let me know if this is not what you had in mind, @stipsan 