### PR TITLE
fix: autotranslate improvements

### DIFF
--- a/src/api/autoTranslate.ts
+++ b/src/api/autoTranslate.ts
@@ -40,7 +40,7 @@ export async function autoTranslate(options: AutoTranslateOptions): Promise<void
     const missingResources = await findMissingResources(locale)
     const localeName = locale.englishName || locale.name
 
-    for await (const entry of missingResources) {
+    for (const entry of missingResources) {
       if (namespaces && !namespaces.includes(entry.namespace)) {
         continue
       }
@@ -70,7 +70,7 @@ export async function autoTranslate(options: AutoTranslateOptions): Promise<void
       }
 
       // For each of the batches, translate the keys
-      for await (const currentBatch of batches) {
+      for (const currentBatch of batches) {
         const tpl = templateMissingResources(ns.indexedResources, currentBatch)
         logger(
           `[${locale.name}] Translating ${batches.indexOf(currentBatch) + 1}/${

--- a/src/api/autoTranslate.ts
+++ b/src/api/autoTranslate.ts
@@ -55,6 +55,8 @@ export async function autoTranslate(options: AutoTranslateOptions): Promise<numb
         continue
       }
 
+      let numTranslatedInNamespace = 0
+
       // Group entry.missingKeys into max 25 keys per request
       const BATCH_SIZE = 25
       const batches = []
@@ -92,13 +94,14 @@ export async function autoTranslate(options: AutoTranslateOptions): Promise<numb
 
           val.value = translation[key.key]
           numTotalTranslated++
+          numTranslatedInNamespace++
         }
+      }
 
-        // Write the bundle back to disk
-        for (const {filePath, resources} of locale.namespaces) {
-          const moduleCode = buildResourceBundle(resources)
-          await writeFormattedFile(filePath, moduleCode)
-        }
+      // Only write back changes if there are actual changes
+      if (numTranslatedInNamespace > 0) {
+        const moduleCode = buildResourceBundle(ns.resources)
+        await writeFormattedFile(ns.filePath, moduleCode)
       }
     }
   }

--- a/src/cli/autoTranslate.ts
+++ b/src/cli/autoTranslate.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv'
+import {parseArgs} from 'node:util'
 import {autoTranslate, pushChanges} from '../api/autoTranslate'
 import {runScript} from '../util/runScript'
-import {parseArgs} from 'util'
 
 // Load environment variables from .env file, where API key for OpenAI is hopefully present.
 // The auto-translation will throw an error if the API key is missing.


### PR DESCRIPTION
Prevents the auto-translator from writing (and reformatting) resource files when no resources were actually translated. Any formatting issues will be caught by the `reconcile` CI workflow.

Also yields the total number of auto-translated resources from `autoTranslate()`, as I initially thought it might be useful to skip the git logic if nothing was auto-translated, but decided against it as there is already logic for checking for changes within the git logic.

Also did some minor code style fixes (imports sorted by TypeScript, don't use for-await loops on non-async iterators)