### PR TITLE
chore: update lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,7 +357,7 @@ importers:
     dependencies:
       sanity:
         specifier: ^3.22.0
-        version: 3.23.4(@types/node@18.18.14)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.1.6)
+        version: 3.25.0(@types/node@18.18.14)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.1.6)
 
   locales/vi-VN:
     dependencies:


### PR DESCRIPTION
We are seeing a ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile after a recent merging of an older PR
