### PR TITLE
feat: auto-merge auto-translations that are missing maintainers

### DIFF
--- a/src/api/autoTranslate.ts
+++ b/src/api/autoTranslate.ts
@@ -352,6 +352,13 @@ export async function pushChanges(): Promise<void> {
         ],
         {cwd: rootPath},
       )
+
+      if (!hasMaintainers) {
+        // Automatically merge PRs that are missing maintainers - there's no one to review
+        await execFile('gh', ['pr', 'merge', branchName, '--squash', '--delete-branch'], {
+          cwd: rootPath,
+        })
+      }
     }
 
     // Switch back to main branch for next locale


### PR DESCRIPTION
Some locales do not currently have maintainers. These are currently marked as such, but has to be manually merged by the Sanity team in order to be scheduled for release. Since we don't know these languages ourselves, we can't really do much besides hit the merge button.

This PR makes it so we automatically merge these instead, so they're ready to  be released.