### PR TITLE
ci: add workflow to nudge maintainers after 7 days of no reviews

### DIFF
--- a/.github/workflows/nudge-stale.yml
+++ b/.github/workflows/nudge-stale.yml
@@ -1,0 +1,31 @@
+name: Nudge stale PRs
+'on':
+  workflow_dispatch:
+  schedule:
+    # Every 12 hours
+    - cron: '0 */12 * * *'
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Use pnpm
+        run: corepack enable && pnpm --version
+
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts
+
+      - name: Nudge stale PRs
+        run: pnpm run ci:nudge-stale
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nudge-stale.yml
+++ b/.github/workflows/nudge-stale.yml
@@ -5,7 +5,7 @@ name: Nudge stale PRs
     # Every 12 hours
     - cron: '0 */12 * * *'
 jobs:
-  auto-merge:
+  nudge-stale:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "check:types": "tsc --noEmit",
     "ci:adjust-labels": "tsx src/cli/adjustLabels",
     "ci:auto-merge-stale": "tsx src/cli/autoMergeStale",
+    "ci:nudge-stale": "tsx src/cli/nudgeStale",
     "clean": "rimraf apps/studio/dist locales/*/dist",
     "dev": "SANITY_STUDIO_DEBUG_I18N=log turbo run dev",
     "format": "prettier --write .",

--- a/src/api/ghLabels.ts
+++ b/src/api/ghLabels.ts
@@ -41,6 +41,13 @@ export const PR_LABEL_CHANGES_REQUESTED = 'changes-requested'
 export const PR_LABEL_AUTO_MERGED_STALE = 'auto-merged-stale'
 
 /**
+ * Label applied when the PR has been nudged for inactivity (maintainers notified by comment)
+ *
+ * @internal
+ */
+export const PR_LABEL_NUDGED = 'nudged'
+
+/**
  * Options for the label adjustments operation
  *
  * @internal

--- a/src/api/nudgeStale.ts
+++ b/src/api/nudgeStale.ts
@@ -2,23 +2,19 @@ import {execFile as execFileCb} from 'node:child_process'
 import {promisify} from 'node:util'
 
 import {outdent} from 'outdent'
-import {ZodError} from 'zod'
-import {fromZodError} from 'zod-validation-error'
 
-import {githubPrListSchema} from '../schemas'
 import type {GitHubPRList, Locale} from '../types'
+import {getPendingAutoTranslatedPRs} from '../util/getPendingAutoTranslatedPRs'
 import {getRootPath} from '../util/getRootPath'
 import {STALE_MERGE_THRESHOLD_DAYS} from './autoMergeStale'
 import {AUTO_TRANSLATE_BRANCH_PREFIX} from './autoTranslate'
-import {PR_LABEL_AWAITING_REVIEW, PR_LABEL_NUDGED} from './ghLabels'
+import {PR_LABEL_NUDGED} from './ghLabels'
 import {getLocaleRegistry} from './registry'
 
 const execFile = promisify(execFileCb)
 
 const ONE_DAY_MS = 864e5
 const STALE_NUDGE_THRESHOLD_DAYS = 7
-const GH_REPO_OWNER = 'sanity-io'
-const GH_REPO_NAME = 'locales'
 
 /**
  * Options for the nudge stale operation
@@ -114,40 +110,9 @@ async function commentOnStalePR(
 }
 
 async function findPendingStaleAutoTranslatedPRs() {
-  const rootPath = await getRootPath()
-  const {stdout} = await execFile(
-    'gh',
-    [
-      'pr',
-      'list',
-      '--label',
-      PR_LABEL_AWAITING_REVIEW,
-      '--json',
-      'createdAt,mergeable,number,headRefName,headRepository,headRepositoryOwner,labels',
-    ],
-    {
-      cwd: rootPath,
-      // eslint-disable-next-line no-process-env
-      env: {...process.env, CLICOLOR: '0'},
-    },
-  )
-
-  let pending: GitHubPRList = []
-  try {
-    pending = githubPrListSchema.parse(JSON.parse(stdout))
-  } catch (err: unknown) {
-    throw err instanceof ZodError ? fromZodError(err) : err
-  }
-
+  const pending = await getPendingAutoTranslatedPRs()
   return pending.filter(
     (pr) =>
-      // PR is in our own repository
-      pr.headRepositoryOwner.login === GH_REPO_OWNER &&
-      pr.headRepository.name === GH_REPO_NAME &&
-      // PR is an auto-translated PR
-      pr.headRefName.startsWith(`${AUTO_TRANSLATE_BRANCH_PREFIX}/`) &&
-      // Does not have any conflicts
-      pr.mergeable === 'MERGEABLE' &&
       // Does not already have the "nudged" label, eg has already been nudged
       !pr.labels.some((label) => label.name === PR_LABEL_NUDGED),
   )

--- a/src/api/nudgeStale.ts
+++ b/src/api/nudgeStale.ts
@@ -105,8 +105,8 @@ async function commentOnStalePR(
     return
   }
 
-  await execFile('gh', ['pr', 'comment', `${pr.number}`, '--body', comment], execOptions)
   await execFile('gh', ['pr', 'edit', `${pr.number}`, '--add-label', addLabel], execOptions)
+  await execFile('gh', ['pr', 'comment', `${pr.number}`, '--body', comment], execOptions)
 }
 
 async function findPendingStaleAutoTranslatedPRs() {

--- a/src/cli/nudgeStale.ts
+++ b/src/cli/nudgeStale.ts
@@ -1,0 +1,24 @@
+import {parseArgs} from 'node:util'
+
+import {nudgeStale} from '../api/nudgeStale'
+import {runScript} from '../util/runScript'
+
+const args = parseArgs({
+  strict: true,
+  options: {
+    'dry-run': {
+      type: 'boolean',
+      description: 'Do not execute any actions, only log what would have been done',
+      default: false,
+    },
+  },
+})
+
+const dryRun = args.values['dry-run'] ?? false
+
+runScript(() =>
+  nudgeStale({
+    logger: (message) => console.log(dryRun ? `[dry-run] ${message}` : message),
+    dryRun,
+  }),
+)

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -263,6 +263,14 @@ export const githubPrListSchema = z.array(
     headRepositoryOwner: z.object({id: z.string(), login: z.string()}),
     mergeable: z.enum(['MERGEABLE', 'CONFLICTING', 'UNKNOWN'] as const),
     number: z.number(),
+    labels: z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        description: z.string().optional(),
+        color: z.string(),
+      }),
+    ),
   }),
 )
 

--- a/src/util/getPendingAutoTranslatedPRs.ts
+++ b/src/util/getPendingAutoTranslatedPRs.ts
@@ -1,0 +1,59 @@
+import {execFile as execFileCb} from 'node:child_process'
+import {promisify} from 'node:util'
+
+import {ZodError} from 'zod'
+import {fromZodError} from 'zod-validation-error'
+
+import {AUTO_TRANSLATE_BRANCH_PREFIX} from '../api/autoTranslate'
+import {PR_LABEL_AWAITING_REVIEW} from '../api/ghLabels'
+import {githubPrListSchema} from '../schemas'
+import type {GitHubPRList} from '../types'
+import {getRootPath} from './getRootPath'
+
+const execFile = promisify(execFileCb)
+
+const GH_REPO_OWNER = 'sanity-io'
+const GH_REPO_NAME = 'locales'
+
+/**
+ * Get a list of pending auto-translated PRs that are awaiting review, and are not in conflict.
+ *
+ * @returns A promise that resolves with a list of PRs
+ */
+export async function getPendingAutoTranslatedPRs(): Promise<GitHubPRList> {
+  const rootPath = await getRootPath()
+  const {stdout} = await execFile(
+    'gh',
+    [
+      'pr',
+      'list',
+      '--label',
+      PR_LABEL_AWAITING_REVIEW,
+      '--json',
+      'createdAt,mergeable,number,headRefName,headRepository,headRepositoryOwner,labels',
+    ],
+    {
+      cwd: rootPath,
+      // eslint-disable-next-line no-process-env
+      env: {...process.env, CLICOLOR: '0'},
+    },
+  )
+
+  let pending: GitHubPRList = []
+  try {
+    pending = githubPrListSchema.parse(JSON.parse(stdout))
+  } catch (err: unknown) {
+    throw err instanceof ZodError ? fromZodError(err) : err
+  }
+
+  return pending.filter(
+    (pr) =>
+      // PR is in our own repository
+      pr.headRepositoryOwner.login === GH_REPO_OWNER &&
+      pr.headRepository.name === GH_REPO_NAME &&
+      // PR is an auto-translated PR
+      pr.headRefName.startsWith(`${AUTO_TRANSLATE_BRANCH_PREFIX}/`) &&
+      // Does not have any conflicts
+      pr.mergeable === 'MERGEABLE',
+  )
+}


### PR DESCRIPTION
Following up on #505 - this PR gives the maintainers a nudge after 7 days of inactivity, to ensure we don't auto-merge PRs without giving maintainers a little heads up.
