### PR TITLE
chore(studio): create a separate workspace per locale

### DIFF
--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -1,6 +1,6 @@
 import {visionTool} from '@sanity/vision'
 import {defineConfig} from 'sanity'
-import {deskTool} from 'sanity/desk'
+import {structureTool} from 'sanity/structure'
 
 import {i18nDemo} from './i18n'
 import {locales} from './locales'
@@ -19,7 +19,7 @@ export default defineConfig({
     // A custom i18n plugin (with a namespace for this demo studio)
     i18nDemo(),
     // Our old trusty structure tool
-    deskTool({structure: structureDefinition}),
+    structureTool({structure: structureDefinition}),
     // And the vision developer tool
     visionTool(),
   ],

--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -1,5 +1,5 @@
 import {visionTool} from '@sanity/vision'
-import {defineConfig} from 'sanity'
+import {defineConfig, type PluginOptions, type WorkspaceOptions} from 'sanity'
 import {structureTool} from 'sanity/structure'
 
 import {i18nDemo} from './i18n'
@@ -7,24 +7,58 @@ import {locales} from './locales'
 import {localizationTest} from './schemas/localizationTest'
 import {structureDefinition} from './structure/definition'
 
-export default defineConfig({
-  title: 'Localization',
+const projectId = 'ppsg7ml5'
+const dataset = 'test'
 
-  projectId: 'ppsg7ml5',
-  dataset: 'test',
+export default defineConfig([
+  // en-US is built-in, but we'll still want a workspace for it
+  withDefaultConfig({id: 'en-US', title: 'English (US)'}),
 
-  plugins: [
-    // All the defined locales
-    ...locales,
-    // A custom i18n plugin (with a namespace for this demo studio)
-    i18nDemo(),
-    // Our old trusty structure tool
-    structureTool({structure: structureDefinition}),
-    // And the vision developer tool
-    visionTool(),
-  ],
+  // Add workspaces for all the locale plugins we have defined
+  ...locales
+    .map((plugin) => localePluginToWorkspace(plugin))
+    .filter((workspace) => workspace !== null)
+    .sort((a, b) => a?.title?.localeCompare(b?.title || '') || 0),
+])
 
-  schema: {
-    types: [localizationTest],
-  },
-})
+function withDefaultConfig(
+  {id, title}: {id: string; title: string},
+  plugin?: PluginOptions,
+): WorkspaceOptions {
+  return {
+    name: id,
+    title: title,
+    basePath: `/${id}`,
+    icon: () => null,
+
+    projectId,
+    dataset,
+
+    plugins: (plugin ? [plugin] : []).concat([
+      // A custom i18n plugin (with a namespace for this demo studio)
+      i18nDemo(),
+      // Our old trusty structure tool
+      structureTool({structure: structureDefinition}),
+      // And the vision developer tool
+      visionTool(),
+    ]),
+
+    schema: {
+      types: [localizationTest],
+    },
+  }
+}
+
+function localePluginToWorkspace(plugin: PluginOptions): WorkspaceOptions | null {
+  const i18n = plugin.i18n || {}
+  if (!Array.isArray(i18n.locales)) {
+    return null
+  }
+
+  const locale = i18n.locales[0]
+  if (!locale) {
+    return null
+  }
+
+  return withDefaultConfig(locale, plugin)
+}

--- a/apps/studio/structure/TestDocumentDeleter.tsx
+++ b/apps/studio/structure/TestDocumentDeleter.tsx
@@ -2,7 +2,7 @@ import {WarningOutlineIcon} from '@sanity/icons'
 import {Box, Button, Card, Container, Flex, Heading, Spinner, Stack, Text} from '@sanity/ui'
 import React, {forwardRef, useCallback, useEffect, useState} from 'react'
 import {Translate, useClient, useDataset, useDocumentStore, useTranslation} from 'sanity'
-import {UserComponent} from 'sanity/desk'
+import {UserComponent} from 'sanity/structure'
 
 import {i18nNamespace} from '../i18n'
 import {hiddenPropName, localizationTest} from '../schemas/localizationTest'

--- a/apps/studio/structure/definition.ts
+++ b/apps/studio/structure/definition.ts
@@ -1,5 +1,5 @@
 import {TrashIcon} from '@sanity/icons'
-import type {ListBuilder, StructureBuilder} from 'sanity/desk'
+import type {ListBuilder, StructureBuilder} from 'sanity/structure'
 
 import {localizationTest} from '../schemas/localizationTest'
 import {TestDocumentDeleter} from './TestDocumentDeleter'


### PR DESCRIPTION
In order to more easily test locales, this PR creates a separate workspace in the studio per locale. 