### PR TITLE
chore: use gpt-4o as model for auto translations

### DIFF
--- a/src/api/autoTranslate.ts
+++ b/src/api/autoTranslate.ts
@@ -14,7 +14,7 @@ import {getLocaleRegistry} from './registry'
 
 const execFile = promisify(execFileCb)
 
-const OPENAI_MODEL = 'gpt-4-1106-preview'
+const OPENAI_MODEL = 'gpt-4o'
 
 /**
  * Prefix that preceeds the name of the auto-translated locale branch


### PR DESCRIPTION
We're currently using a preview model of gpt-4, which is probably not ideal.

The new gpt-4o model, according to the docs;
> …has the same high intelligence as GPT-4 Turbo but is much more efficient—it generates text 2x faster and is 50% cheaper. Additionally, GPT-4o has … and _**performance across non-English languages**_ of any of our models. 

In particular, we want better performance on non-English languages - since thats all we're doing here, but the additional speedup would be nice too, as we keep adding more locales.