### PR TITLE
fix(nb-NO): avoid duplicate words in tooltip

### DIFF
--- a/locales/nb-NO/src/structure.ts
+++ b/locales/nb-NO/src/structure.ts
@@ -33,7 +33,7 @@ export default removeUndefinedLocaleResources({
   /** Tooltip when publish button is disabled because the document is already published, and published time is unavailable.*/
   'action.publish.already-published.no-time-ago.tooltip': 'Allerede publisert',
   /** Tooltip when publish button is disabled because the document is already published.*/
-  'action.publish.already-published.tooltip': 'Publisert for {{timeSincePublished}} siden',
+  'action.publish.already-published.tooltip': 'Publisert {{timeSincePublished}}',
   /** Tooltip when action is disabled because the studio is not ready.*/
   'action.publish.disabled.not-ready': 'Operasjonen er ikke klar',
   /** Label for action when there are pending changes.*/


### PR DESCRIPTION
This PR cleans up the already published tooltip. The `timeSincePublished` variabled already contains the word "for" and "siden".

<img width="272" alt="image" src="https://github.com/user-attachments/assets/8ed79e16-acad-4bc1-9b96-af967b385322">
