### PR TITLE
build: use correct outputs for turbo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**", "!.next/cache/**", "apps/studio/dist/**", "apps/studio/.sanity/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**", ".sanity/**"]
     },
     "lint": {},
     "dev": {


### PR DESCRIPTION
We weren't getting the benefits of turbo caching for the locale packages. The patterns are relative _to the packages_, not to the root.