### PR TITLE
fix(ci): fixes release-please workflow conditional

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,25 +39,25 @@ jobs:
 
       # Publish to NPM on new releases
       - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.releases_created || github.event.inputs.publish == 'true' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.publish == 'true' }}
       - uses: pnpm/action-setup@v2
-        if: ${{ steps.release.outputs.releases_created || github.event.inputs.publish == 'true' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.publish == 'true' }}
       - uses: actions/setup-node@v4
-        if: ${{ steps.release.outputs.releases_created || github.event.inputs.publish == 'true' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.publish == 'true' }}
         with:
           cache: pnpm
           node-version: lts/*
       - name: install deps
         run: corepack enable && pnpm --version && pnpm install --ignore-scripts
-        if: ${{ steps.release.outputs.releases_created || github.event.inputs.publish == 'true' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.publish == 'true' }}
       - name: Set publishing config
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
-        if: ${{ steps.release.outputs.releases_created || github.event.inputs.publish == 'true' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.publish == 'true' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
       # Release Please has already incremented versions and published tags, so we just
       # need to publish all unpublished versions to NPM here
       - run: pnpm -r publish
-        if: ${{ steps.release.outputs.releases_created || github.event.inputs.publish == 'true' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.publish == 'true' }}
         env:
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Description

Release Please provides two types of release outputs, depending on the type of repository setup:

- **Single-package repositories**: If you publish the root `package.json` (i.e., the `.` in Release Please), the action outputs `release_created` (singular).
- **Monorepositories**: If you publish sub-packages rather than the root, the action outputs `releases_created` (plural).  
For more details, refer to the [Release Please Action documentation](https://github.com/googleapis/release-please-action?tab=readme-ov-file#outputs).

---

## What was the issue with the previous setup?

In the current version, it tries to compare `'false' || github['event']['inputs']['publish'] == 'true'`, which returns `'false'` as a string, always making this expression truthy.

---

## Changes in this PR

This PR adjusts the logic to correctly handle outputs, ensuring the action behaves as expected. The fix has been verified in a test run.
