### PR TITLE
fix(nl-NL): lowercase 'releases' in release.menu.view-releases

### DIFF
--- a/locales/nl-NL/src/studio.ts
+++ b/locales/nl-NL/src/studio.ts
@@ -1503,7 +1503,7 @@ export default removeUndefinedLocaleResources({
   /** Tooltip for the release menu */
   'release.menu.tooltip': 'Acties',
   /** Menu item label for viewing content releases */
-  'release.menu.view-releases': 'Content Releases bekijken',
+  'release.menu.view-releases': 'Content releases bekijken',
   /** Label for draft perspective in navbar */
   'release.navbar.drafts': 'Concepten',
   /** Label for published releases in navbar */


### PR DESCRIPTION
Fixes a capitalization inconsistency in the Dutch locale.

`release.menu.view-releases` had `'Content Releases bekijken'` where `Releases` was incorrectly capitalized. Dutch uses sentence case, so the correct value is `'Content releases bekijken'`.

Closes #1696