### PR TITLE
chore: set minimumReleaseAge to 3 days for third-party deps

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,12 @@ packages:
   - 'apps/*'
   - 'packages/*'
   - 'locales/*'
+
+minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - '@portabletext/*'
+  - '@sanity/*'
+  - '@types/*'
+  - 'groq'
+  - 'groq-js'
+  - 'sanity'


### PR DESCRIPTION
## Summary
- Adds `minimumReleaseAge: 4320` (3 days) to `pnpm-workspace.yaml` so newly published third-party versions sit for 3 days before pnpm will install them — a small but real mitigation against compromised package releases.
- Excludes `@sanity/*`, `@portabletext/*`, `groq`, `groq-js`, `sanity`, and `@types/*` so internal releases install immediately.

Mirrors the pattern already in place in `sanity-io/sanity`, `sanity-io/cli`, and `sanity-io/www-sanity-io`.

## Test plan
- [ ] CI green
- [ ] `pnpm install` resolves without complaints