### PR TITLE
fix(pt-BR): address remaining review feedback from #1776

### DIFF
--- a/locales/pt-BR/src/presentation.ts
+++ b/locales/pt-BR/src/presentation.ts
@@ -15,7 +15,7 @@ export default removeUndefinedLocaleResources({
   /** The text shown if the document list is unable to render */
   'document-list-pane.error.text': 'Não foi possível renderizar a lista de documentos',
   /** The label for the ordering that lists documents in the order they appear on the page */
-  'document-list-pane.ordering.by-appearance': 'Por aparência',
+  'document-list-pane.ordering.by-appearance': 'Por ordem de aparição',
   /** The label for the ordering that lists documents by when they were last edited */
   'document-list-pane.ordering.last-edited': 'Última edição',
 

--- a/locales/pt-BR/src/studio.ts
+++ b/locales/pt-BR/src/studio.ts
@@ -128,7 +128,7 @@ export default removeUndefinedLocaleResources({
   'asset-source.dialog.insert-asset-error':
     'Erro ao inserir o ativo. Consulte o console para mais informações.',
   /** Toast title shown when the list of assets failed to load */
-  'asset-source.dialog.load-error': 'Falha ao carregar assets',
+  'asset-source.dialog.load-error': 'Falha ao carregar ativos',
   /** Select asset dialog load more items */
   'asset-source.dialog.load-more': 'Carregar mais',
   /** Text shown when selecting a file but there's no files to select from
@@ -493,7 +493,7 @@ export default removeUndefinedLocaleResources({
   'document-group-inventory.action.cancel': 'Cancelar',
   /** The label used in the feedback dialog asking how easy the document group inventory is to use */
   'document-group-inventory.feedback.sentiment-label':
-    'Quão fácil ou difícil é usar a nova versão do inventário?',
+    'Quão fácil ou difícil é usar o novo inventário de versões?',
   /** The label for the input that filters the variants in the document group inventory */
   'document-group-inventory.filter-string.label': 'Filtrar {{subject}}',
   /** The document inventory title (plural) */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the auto-merged [#1776](https://github.com/sanity-io/locales/pull/1776), which landed with unresolved review feedback.

### Nick’s suggestion ([discussion](https://github.com/sanity-io/locales/pull/1776#discussion_r3561375111))

Already present on `main` from the final #1776 commit:

`'document-group.delete.preview-item.preview-unavailable.title': 'Pré-visualização indisponível'`

No further change needed for that string.

### Remaining fixes in this PR

Addresses other unresolved review notes from #1776:

| Key | Before | After |
| --- | --- | --- |
| `asset-source.dialog.load-error` | Falha ao carregar **assets** | Falha ao carregar **ativos** |
| `document-group-inventory.feedback.sentiment-label` | …a **nova versão do inventário**? | …o **novo inventário de versões**? |
| `document-list-pane.ordering.by-appearance` | Por **aparência** | Por **ordem de aparição** |

These match the English source meanings (“Failed to load assets”, “version inventory”, “order they appear on the page”) and existing pt-BR terminology elsewhere in the locale.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00d07f4b-7fa0-4669-8f52-04d7825b07f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00d07f4b-7fa0-4669-8f52-04d7825b07f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

