### PR TITLE
docs: Cursor Cloud agent setup notes for Sanity locales

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is the [Sanity Studio Locales](https://github.com/sanity-io/locales) monorepo: community locale packages under `locales/*`, plus a demo Studio at `apps/studio` that loads every locale as a workspace.
+
+### Runtime
+
+- Requires **Node `>=24.18.0`** (`package.json` `engines`) and **pnpm** (`packageManager`: `pnpm@10.29.2`). Prefer a login shell so nvm’s default Node 24 is on `PATH` ahead of any older system Node shim.
+- Standard commands are in root `package.json` / `CONTRIBUTING.md`: `pnpm install`, `pnpm check:lint`, `pnpm test`, `pnpm build`, `pnpm dev`.
+
+### Services
+
+| Service | Command | Notes |
+| --- | --- | --- |
+| i18n demo Studio | `pnpm dev` (from repo root) | Serves at `http://localhost:3333`. Uses Sanity project `ppsg7ml5` / dataset `test`. Vite aliases locale packages to their `src/` so you can edit translations without rebuilding. |
+
+### Studio auth (cloud / local)
+
+- The Studio requires a Sanity session. In this environment, authenticate by opening:
+
+  ```bash
+  node -e "const t=process.env.SANITY_TEST_STUDIO_AUTH_TOKEN; console.log('http://localhost:3333/<locale>#token=' + encodeURIComponent(t))"
+  ```
+
+  Example locale paths: `en-US`, `de-DE`, `ja-JP`. Always `encodeURIComponent` the token. Do not commit or log the token.
+- Secret name: `SANITY_TEST_STUDIO_AUTH_TOKEN`.
+- Pre-auth chrome (login / workspace picker) often stays on a default locale; **full UI translation is visible after auth** inside a locale workspace. That is expected.
+
+### Lint / test / build caveats
+
+- CI (`.github/workflows/test.yaml`) runs `pnpm check:lint`, `pnpm test`, and `pnpm build --filter=./locales/*`. It does **not** run `pnpm check:types`.
+- `pnpm check:types` currently fails on main (root `tsconfig` uses `moduleResolution: "node"` vs studio package exports). Treat lint + test as the gate unless you are specifically fixing types.
+- Locale package builds via `@sanity/pkg-utils` v11 have been failing on main (api-extractor / `moduleResolution=node10` under TypeScript 5.9). Reproducing that failure locally is expected until fixed upstream in the repo; do not treat it as an environment misconfiguration.
+- `pnpm install` may warn that esbuild’s build script was ignored; the `@esbuild/linux-x64` binary is still present and `sanity dev` / Vite work without approving builds.
+
+### Hello-world check
+
+After `pnpm dev`, open an auth URL for a non-English workspace (e.g. `de-DE`), confirm German Studio chrome (e.g. **Entwurf**, **Veröffentlichen**), and create/save a **Localization test** draft.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud–specific guidance for developing in this repo (Sanity Studio Locales monorepo).

## Environment setup performed

- Installed **Node 24.18.0** (matches `engines` / CI) and used **pnpm 10.29.2**
- Ran `pnpm install`
- Verified `pnpm check:lint` (pass), `pnpm test` (217 pass)
- Confirmed locale package build failure matches current main CI (`@sanity/pkg-utils` v11) — not an env misconfiguration
- Ran `pnpm dev` (Studio at `http://localhost:3333`)
- Authenticated via `#token=` + `SANITY_TEST_STUDIO_AUTH_TOKEN` and created a **Localization test** draft in the **Deutsch** workspace

## Update script

`pnpm install` (dependency refresh only)

Please merge the AGENTS.md updates so future agents remember Studio auth and the Node/build caveats.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96dbabb1-1830-4f6a-b76b-742b9c3784a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96dbabb1-1830-4f6a-b76b-742b9c3784a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

