### PR TITLE
chore: Cursor approval routing for autotranslate locale PRs

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -2,13 +2,13 @@
 
 ## Autofix
 
-Enable autofix for Bugbot findings. Prefer fixing by **opening a new pull request** (Create New Pull Request / Create New Branch), not by committing onto the finding’s existing PR branch.
+Enable autofix for Bugbot findings. Fixes must land on a **new branch** (**Create New Branch**), not on the reviewed PR branch.
 
 When Autofix runs:
 
 - Spawn a Cloud Agent to address the reported finding(s).
-- Push the fix to a **new branch** and open a **new PR** against the appropriate base.
-- Reference the original PR and Bugbot finding in the new PR description.
-- Do **not** push autofix commits directly onto the reviewed PR branch.
+- Push the fix to a **new branch** (do not commit onto the reviewed PR branch).
+- Reference the original PR and Bugbot finding in the Autofix follow-up.
+- Do **not** use **Commit to Existing Branch**.
 
-Dashboard Autofix mode for this repository should be set to **Create New Pull Request** (or **Create New Branch** if that option is unavailable) in [Bugbot Automations](https://cursor.com/automations/from-cursor/bugbot).
+Dashboard Autofix mode for this repository: **Create New Branch** (recommended).

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,14 @@
+# Bugbot
+
+## Autofix
+
+Enable autofix for Bugbot findings. Prefer fixing by **opening a new pull request** (Create New Pull Request / Create New Branch), not by committing onto the finding’s existing PR branch.
+
+When Autofix runs:
+
+- Spawn a Cloud Agent to address the reported finding(s).
+- Push the fix to a **new branch** and open a **new PR** against the appropriate base.
+- Reference the original PR and Bugbot finding in the new PR description.
+- Do **not** push autofix commits directly onto the reviewed PR branch.
+
+Dashboard Autofix mode for this repository should be set to **Create New Pull Request** (or **Create New Branch** if that option is unavailable) in [Bugbot Automations](https://cursor.com/automations/from-cursor/bugbot).

--- a/.cursor/approval-policies/ROUTING.md
+++ b/.cursor/approval-policies/ROUTING.md
@@ -1,0 +1,10 @@
+- product: Autotranslated locale strings
+  boundary: locales/*/src/**/*.ts
+  policies:
+    - .cursor/approval-policies/autotranslate-policy.md
+    - Strict allowlist — only evaluate PRs whose changed files are exclusively under locales/*/src/**/*.ts; skip otherwise
+    - Only evaluate PRs that have the autotranslate label; skip PRs without it
+    - autotranslate + awaiting-review → skip (do not approve or deny)
+    - autotranslate + changes-requested → deny
+    - autotranslate + nudged (and no awaiting-review) → approve
+    - autotranslate + maintainerless → approve

--- a/.cursor/approval-policies/autotranslate-policy.md
+++ b/.cursor/approval-policies/autotranslate-policy.md
@@ -1,0 +1,27 @@
+# Autotranslate locale approval policy
+
+Applies only to PRs whose changed files are exclusively under
+`locales/*/src/**/*.ts` (see `.cursor/approval-policies/ROUTING.md`).
+
+## Scope gates (evaluate first)
+
+Skip (do not approve or deny) when any of the following is true:
+
+- The PR does **not** have the `autotranslate` label.
+- Any changed file is **outside** `locales/*/src/**/*.ts`.
+
+## Label decisions (`autotranslate` required)
+
+Evaluate labels in this order. Stop at the first matching rule:
+
+1. **`autotranslate` + `awaiting-review`** → **skip** (do not approve or deny), even if `nudged` or other labels are also present.
+2. **`autotranslate` + `changes-requested`** → **deny**.
+3. **`autotranslate` + `nudged`** and **no** `awaiting-review` → **approve**.
+4. **`autotranslate` + `maintainerless`** → **approve**.
+
+If the PR has `autotranslate` but matches none of the rules above → **skip**.
+
+## Notes
+
+- `awaiting-review` always wins over `nudged` / `maintainerless` (skip, never approve while awaiting review).
+- When both `changes-requested` and an approve-eligible label appear together, prefer **deny**.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Cursor PR Routing & Approval policy files and a Bugbot repo rule for this locales monorepo.

## Files

- `.cursor/approval-policies/ROUTING.md` — YAML routing with strict allowlist `locales/*/src/**/*.ts`
- `.cursor/approval-policies/autotranslate-policy.md` — ordered label decisions (skip / approve / deny)
- `.cursor/BUGBOT.md` — Autofix via **Create New Branch** (not commits on the reviewed branch)

## Approval routing rules

| Condition | Action |
| --- | --- |
| Files outside `locales/*/src/**/*.ts`, or missing `autotranslate` | skip |
| `autotranslate` + `awaiting-review` | skip |
| `autotranslate` + `nudged` (no `awaiting-review`) | approve |
| `autotranslate` + `maintainerless` | approve |
| `autotranslate` + `changes-requested` | deny |

## Bugbot Autofix

Dashboard Autofix mode is **Create New Branch** (team confirmed). `.cursor/BUGBOT.md` documents that preference.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96dbabb1-1830-4f6a-b76b-742b9c3784a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96dbabb1-1830-4f6a-b76b-742b9c3784a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

