### PR TITLE
chore: update autotranslate to claude-sonnet-5

### DIFF
--- a/src/api/autoTranslate.ts
+++ b/src/api/autoTranslate.ts
@@ -18,7 +18,21 @@ import {getLocaleRegistry} from './registry'
 
 const execFile = promisify(execFileCb)
 
-const ANTHROPIC_MODEL = 'claude-sonnet-4-6'
+const ANTHROPIC_MODEL = 'claude-sonnet-5'
+
+/**
+ * Controls how many tokens the model spends (thinking depth, verbosity), not sampling
+ * randomness. Adaptive thinking is on by default on this model, and `low` lets it skip
+ * thinking entirely on simple requests - closest to how this workload behaved on
+ * Sonnet 4.6, which ran without thinking. Step up to `medium` if translations regress.
+ */
+const ANTHROPIC_EFFORT = 'low'
+
+/**
+ * Ceiling for thinking plus response tokens. Generous on purpose: unused budget is not
+ * billed, and a truncated response arrives without the tool call we require.
+ */
+const ANTHROPIC_MAX_TOKENS = 16000
 
 /**
  * Prefix that preceeds the name of the auto-translated locale branch
@@ -221,11 +235,11 @@ async function translateText(text: string, targetLanguage: string): Promise<stri
   }
 
   // Use tool calling to guarantee valid JSON output. The model is forced to call
-  // this tool, so the response is always machine-parseable — no markdown fences,
+  // this tool, so a completed response is machine-parseable — no markdown fences,
   // no trailing text, no truncated JSON.
   const message = await anthropic.messages.create({
     model: ANTHROPIC_MODEL,
-    max_tokens: 4096,
+    max_tokens: ANTHROPIC_MAX_TOKENS,
     system: getSystemPrompt(),
     messages: [
       {
@@ -233,8 +247,7 @@ async function translateText(text: string, targetLanguage: string): Promise<stri
         content: `I would like this translated to ${targetLanguage}:\n\n${text}`,
       },
     ],
-    // oxlint-disable-next-line typescript/no-deprecated -- deterministic output is preferred for translations, and the model in use still supports setting temperature
-    temperature: 0,
+    output_config: {effort: ANTHROPIC_EFFORT},
     tools: [
       {
         name: 'submit_translations',
@@ -251,7 +264,9 @@ async function translateText(text: string, targetLanguage: string): Promise<stri
 
   const toolBlock = message.content.find((block) => block.type === 'tool_use')
   if (!toolBlock || toolBlock.type !== 'tool_use') {
-    throw new Error('No tool_use block in response')
+    // A `max_tokens` stop reason means thinking plus response outgrew the budget,
+    // which is worth distinguishing from the model declining to call the tool.
+    throw new Error(`No tool_use block in response (stop_reason: ${message.stop_reason})`)
   }
 
   return JSON.stringify(toolBlock.input)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Moves the autotranslate job from `claude-sonnet-4-6` to `claude-sonnet-5`.

This is not a one-line model swap. Sonnet 5 introduces two breaking API changes that both affect this call site.

## Changes

- **`temperature: 0` removed.** Setting `temperature`, `top_p` or `top_k` to a non-default value returns a 400 error on Claude 4.7 and later models. The SDK still types the field (only `1.0` is accepted, for backwards compatibility), so nothing would have caught this at build time — every batch would have failed at runtime. Effort is not a replacement for temperature: temperature governed sampling randomness, effort governs token spend. Sampling now runs at the default temperature, so expect slightly more run-to-run variation.
- **`output_config.effort` pinned to `low`.** Adaptive thinking is on by default on Sonnet 5, whereas Sonnet 4.6 ran with thinking entirely off because the request never passed a `thinking` field. At `low` effort the model can skip thinking on simple requests, which is the closest match to previous behaviour, and Anthropic recommends `low` for high-volume non-coding workloads. It lives in a named constant so it can be stepped to `medium` in one line if translations regress.
- **`max_tokens` raised from `4096` to `16000`.** Thinking tokens count against `max_tokens`, and Sonnet 5's new tokenizer maps the same text to roughly 1.0–1.35x as many tokens. `max_tokens` is a ceiling rather than a reservation, so unused budget is not billed. Without headroom, a truncated response arrives with no `tool_use` block, the existing guard throws, and because `pMap` fails fast one bad batch would abort every remaining locale.
- **`stop_reason` added to the tool_use guard**, so a truncation is distinguishable from the model declining to call the tool.

Adaptive thinking is deliberately left on rather than passing `thinking: {type: 'disabled'}` — Anthropic warns that disabling thinking can make models emit tool calls as plain text, which would defeat the forced-tool-call mechanism this code relies on for valid JSON.

No dependency change is needed here. `main` independently bumped `@anthropic-ai/sdk` to `0.116.0` in #1872, which types `claude-sonnet-5` as a first-class model id and keeps `output_config.effort` unchanged; this branch has been rebased onto that and re-verified against it.

## Cost

Per-token pricing is identical to Sonnet 4.6 at standard rates ($3/$15 per MTok; the $2/$10 introductory rate ended August 31, 2026). The tokenizer change makes an equivalent request somewhat more expensive, and `low` effort keeps thinking spend near zero. Absolute spend stays small — a routine run translates a few dozen batches, well under a dollar.

## Rebased onto `main`

This branch is rebased onto `main` (linear history, single commit). Along the way `main` picked up #1859, the toolchain modernization (oxlint, oxfmt, TypeScript 7, pnpm 11, changesets, knip), which touched this same file. Two conflicts in `translateText`, both mechanical, plus one point worth a reviewer's attention.

**Worth a look:** #1859 added an explicit suppression to keep `temperature: 0` alive:

```ts
// oxlint-disable-next-line typescript/no-deprecated -- deterministic output is preferred for translations, and the model in use still supports setting temperature
temperature: 0,
```

That comment states a real preference — deterministic output for translations — which this PR makes unachievable, since Sonnet 5 rejects the parameter at any effort level. Note the justification is conditional on "the model in use still supports setting temperature," which stops being true here, so the suppression and the parameter both had to go. Flagging it because the determinism preference was deliberate, not incidental. If determinism matters more than the upgrade, the alternative is staying on Sonnet 4.6.

Both conflicts also had to shed their lint suppressions, because the new config sets `reportUnusedDisableDirectives: "error"`. Verified in both directions: keeping the old `eslint-disable-next-line camelcase` fails with `Unused eslint-disable directive`, and keeping `main`'s suppression after `temperature` is gone fails with `Unused oxlint-disable directive`.

All of `main`'s other changes to this file are preserved — the changeset writing in `pushChanges`, `(val.comments ?? []).join(',')` in the template, and the `.join(', ')` in the locale error message.

## Verification

No `ANTHROPIC_API_KEY` was available, so translation quality could not be measured. Instead the real code path was driven against a local mock endpoint via `ANTHROPIC_BASE_URL`, using the genuinely-missing `be-BY` resources (three namespaces, three batches). Re-run after the rebase against SDK 0.116.0. Mock translations written to `locales/be-BY` during testing were reverted and are not part of this PR.

Captured request bodies, before and after:

| Parameter | Before | After |
| --- | --- | --- |
| `model` | `claude-sonnet-4-6` | `claude-sonnet-5` |
| `temperature` | `0` | absent |
| `max_tokens` | `4096` | `16000` |
| `output_config` | absent | `{"effort":"low"}` |

All eight payload assertions passed across the three requests, including that `temperature`, `top_p`, `top_k` and `thinking` are absent and the forced tool call is retained. A separate mock returning `stop_reason: "max_tokens"` with no `tool_use` block confirmed the hardened error: `No tool_use block in response (stop_reason: max_tokens)`.

Full CI gate green locally on the rebased result: `pnpm check:lint` (0 problems), `pnpm knip` (0), `pnpm test` (217/217), `pnpm build --filter=./locales/*` (31/31), and `oxfmt --check` clean.

## Follow-up for maintainers

Translation quality can only be judged on real output. Recommend triggering the **AI translate** workflow for a single locale via `workflow_dispatch` before letting it run across all 31, and reviewing that diff for the failure modes this workload is exposed to but has no automated coverage for: dropped `{{count}}`-style placeholders, wrong plural forms, and translated brand terms.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fb206a9-dde2-4119-8207-aa5e3b66504c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fb206a9-dde2-4119-8207-aa5e3b66504c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

