### PR TITLE
chore: simplify locale package build scripts

### DIFF
--- a/locales/be-BY/package.json
+++ b/locales/be-BY/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-be-by",
   "version": "1.1.37",
   "private": false,
-  "description": "Belarusian / Беларуская locale/translation for Sanity Studio",
+  "description": "Belarusian / \u0411\u0435\u043b\u0430\u0440\u0443\u0441\u043a\u0430\u044f locale/translation for Sanity Studio",
   "keywords": [
     "be-BY",
     "i18n",
@@ -59,9 +59,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/be-BY/package.json
+++ b/locales/be-BY/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-be-by",
   "version": "1.1.37",
   "private": false,
-  "description": "Belarusian / \u0411\u0435\u043b\u0430\u0440\u0443\u0441\u043a\u0430\u044f locale/translation for Sanity Studio",
+  "description": "Belarusian / Беларуская locale/translation for Sanity Studio",
   "keywords": [
     "be-BY",
     "i18n",

--- a/locales/ca-ES/package.json
+++ b/locales/ca-ES/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-ca-es",
   "version": "1.0.16",
   "private": false,
-  "description": "Catalan / Català locale/translation for Sanity Studio",
+  "description": "Catalan / Catal\u00e0 locale/translation for Sanity Studio",
   "keywords": [
     "ca-ES",
     "i18n",
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/ca-ES/package.json
+++ b/locales/ca-ES/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-ca-es",
   "version": "1.0.16",
   "private": false,
-  "description": "Catalan / Catal\u00e0 locale/translation for Sanity Studio",
+  "description": "Catalan / Català locale/translation for Sanity Studio",
   "keywords": [
     "ca-ES",
     "i18n",

--- a/locales/cs-CZ/package.json
+++ b/locales/cs-CZ/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-cs-cz",
   "version": "1.1.36",
   "private": false,
-  "description": "Czech / \u010ce\u0161tina locale/translation for Sanity Studio",
+  "description": "Czech / Čeština locale/translation for Sanity Studio",
   "keywords": [
     "cs-CZ",
     "i18n",

--- a/locales/cs-CZ/package.json
+++ b/locales/cs-CZ/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-cs-cz",
   "version": "1.1.36",
   "private": false,
-  "description": "Czech / Čeština locale/translation for Sanity Studio",
+  "description": "Czech / \u010ce\u0161tina locale/translation for Sanity Studio",
   "keywords": [
     "cs-CZ",
     "i18n",
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/da-DK/package.json
+++ b/locales/da-DK/package.json
@@ -59,9 +59,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/de-DE/package.json
+++ b/locales/de-DE/package.json
@@ -59,9 +59,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/es-ES/package.json
+++ b/locales/es-ES/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-es-es",
   "version": "1.2.38",
   "private": false,
-  "description": "Spanish / Espa\u00f1ol locale/translation for Sanity Studio",
+  "description": "Spanish / Español locale/translation for Sanity Studio",
   "keywords": [
     "es-ES",
     "i18n",

--- a/locales/es-ES/package.json
+++ b/locales/es-ES/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-es-es",
   "version": "1.2.38",
   "private": false,
-  "description": "Spanish / Español locale/translation for Sanity Studio",
+  "description": "Spanish / Espa\u00f1ol locale/translation for Sanity Studio",
   "keywords": [
     "es-ES",
     "i18n",
@@ -63,9 +63,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/fi-FI/package.json
+++ b/locales/fi-FI/package.json
@@ -50,9 +50,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/fr-FR/package.json
+++ b/locales/fr-FR/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-fr-fr",
   "version": "1.2.36",
   "private": false,
-  "description": "French / Français locale/translation for Sanity Studio",
+  "description": "French / Fran\u00e7ais locale/translation for Sanity Studio",
   "keywords": [
     "fr-FR",
     "i18n",
@@ -63,9 +63,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/fr-FR/package.json
+++ b/locales/fr-FR/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-fr-fr",
   "version": "1.2.36",
   "private": false,
-  "description": "French / Fran\u00e7ais locale/translation for Sanity Studio",
+  "description": "French / Français locale/translation for Sanity Studio",
   "keywords": [
     "fr-FR",
     "i18n",

--- a/locales/hr-HR/package.json
+++ b/locales/hr-HR/package.json
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/hu-HU/package.json
+++ b/locales/hu-HU/package.json
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/is-IS/package.json
+++ b/locales/is-IS/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-is-is",
   "version": "1.2.32",
   "private": false,
-  "description": "Icelandic / Íslenska locale/translation for Sanity Studio",
+  "description": "Icelandic / \u00cdslenska locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "is-IS",
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/is-IS/package.json
+++ b/locales/is-IS/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-is-is",
   "version": "1.2.32",
   "private": false,
-  "description": "Icelandic / \u00cdslenska locale/translation for Sanity Studio",
+  "description": "Icelandic / Íslenska locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "is-IS",

--- a/locales/it-IT/package.json
+++ b/locales/it-IT/package.json
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/ja-JP/package.json
+++ b/locales/ja-JP/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-ja-jp",
   "version": "1.1.39",
   "private": false,
-  "description": "Japanese / \u65e5\u672c\u8a9e locale/translation for Sanity Studio",
+  "description": "Japanese / 日本語 locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "ja-JP",

--- a/locales/ja-JP/package.json
+++ b/locales/ja-JP/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-ja-jp",
   "version": "1.1.39",
   "private": false,
-  "description": "Japanese / 日本語 locale/translation for Sanity Studio",
+  "description": "Japanese / \u65e5\u672c\u8a9e locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "ja-JP",
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/ka-GE/package.json
+++ b/locales/ka-GE/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-ka-ge",
   "version": "1.0.34",
   "private": false,
-  "description": "Georgian / ქართული locale/translation for Sanity Studio",
+  "description": "Georgian / \u10e5\u10d0\u10e0\u10d7\u10e3\u10da\u10d8 locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "ka-GE",
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/ka-GE/package.json
+++ b/locales/ka-GE/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-ka-ge",
   "version": "1.0.34",
   "private": false,
-  "description": "Georgian / \u10e5\u10d0\u10e0\u10d7\u10e3\u10da\u10d8 locale/translation for Sanity Studio",
+  "description": "Georgian / ქართული locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "ka-GE",

--- a/locales/kn-IN/package.json
+++ b/locales/kn-IN/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-kn-in",
   "version": "1.0.36",
   "private": false,
-  "description": "Kannada (India) / ಕನ್ನಡ locale/translation for Sanity Studio",
+  "description": "Kannada (India) / \u0c95\u0ca8\u0ccd\u0ca8\u0ca1 locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "kn-IN",
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/kn-IN/package.json
+++ b/locales/kn-IN/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-kn-in",
   "version": "1.0.36",
   "private": false,
-  "description": "Kannada (India) / \u0c95\u0ca8\u0ccd\u0ca8\u0ca1 locale/translation for Sanity Studio",
+  "description": "Kannada (India) / ಕನ್ನಡ locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "kn-IN",

--- a/locales/ko-KR/package.json
+++ b/locales/ko-KR/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-ko-kr",
   "version": "1.1.38",
   "private": false,
-  "description": "Korean / 한국어 locale/translation for Sanity Studio",
+  "description": "Korean / \ud55c\uad6d\uc5b4 locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "ko-KR",
@@ -50,9 +50,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/ko-KR/package.json
+++ b/locales/ko-KR/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-ko-kr",
   "version": "1.1.38",
   "private": false,
-  "description": "Korean / \ud55c\uad6d\uc5b4 locale/translation for Sanity Studio",
+  "description": "Korean / 한국어 locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "ko-KR",

--- a/locales/nb-NO/package.json
+++ b/locales/nb-NO/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-nb-no",
   "version": "1.1.38",
   "private": false,
-  "description": "Norwegian (Bokm\u00e5l) / Norsk (Bokm\u00e5l) locale/translation for Sanity Studio",
+  "description": "Norwegian (Bokmål) / Norsk (Bokmål) locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",

--- a/locales/nb-NO/package.json
+++ b/locales/nb-NO/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-nb-no",
   "version": "1.1.38",
   "private": false,
-  "description": "Norwegian (Bokmål) / Norsk (Bokmål) locale/translation for Sanity Studio",
+  "description": "Norwegian (Bokm\u00e5l) / Norsk (Bokm\u00e5l) locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",
@@ -59,9 +59,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/nl-NL/package.json
+++ b/locales/nl-NL/package.json
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/nn-NO/package.json
+++ b/locales/nn-NO/package.json
@@ -50,9 +50,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/pl-PL/package.json
+++ b/locales/pl-PL/package.json
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/pt-BR/package.json
+++ b/locales/pt-BR/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-pt-br",
   "version": "1.1.36",
   "private": false,
-  "description": "Portuguese (Brazil) / Portugu\u00eas (Brasil) locale/translation for Sanity Studio",
+  "description": "Portuguese (Brazil) / Português (Brasil) locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",

--- a/locales/pt-BR/package.json
+++ b/locales/pt-BR/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-pt-br",
   "version": "1.1.36",
   "private": false,
-  "description": "Portuguese (Brazil) / Português (Brasil) locale/translation for Sanity Studio",
+  "description": "Portuguese (Brazil) / Portugu\u00eas (Brasil) locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/pt-PT/package.json
+++ b/locales/pt-PT/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-pt-pt",
   "version": "1.1.36",
   "private": false,
-  "description": "Portuguese / Portugu\u00eas locale/translation for Sanity Studio",
+  "description": "Portuguese / Português locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",

--- a/locales/pt-PT/package.json
+++ b/locales/pt-PT/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-pt-pt",
   "version": "1.1.36",
   "private": false,
-  "description": "Portuguese / Português locale/translation for Sanity Studio",
+  "description": "Portuguese / Portugu\u00eas locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",
@@ -59,9 +59,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/ro-RO/package.json
+++ b/locales/ro-RO/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-ro-ro",
   "version": "1.0.17",
   "private": false,
-  "description": "Romanian / Rom\u00e2n\u0103 locale/translation for Sanity Studio",
+  "description": "Romanian / Română locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",

--- a/locales/ro-RO/package.json
+++ b/locales/ro-RO/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-ro-ro",
   "version": "1.0.17",
   "private": false,
-  "description": "Romanian / Română locale/translation for Sanity Studio",
+  "description": "Romanian / Rom\u00e2n\u0103 locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/ru-KZ/package.json
+++ b/locales/ru-KZ/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-ru-kz",
   "version": "1.1.35",
   "private": false,
-  "description": "Russian (Kazakhstan) / \u0420\u0443\u0441\u0441\u043a\u0438\u0439 locale/translation for Sanity Studio",
+  "description": "Russian (Kazakhstan) / Русский locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",

--- a/locales/ru-KZ/package.json
+++ b/locales/ru-KZ/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-ru-kz",
   "version": "1.1.35",
   "private": false,
-  "description": "Russian (Kazakhstan) / Русский locale/translation for Sanity Studio",
+  "description": "Russian (Kazakhstan) / \u0420\u0443\u0441\u0441\u043a\u0438\u0439 locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/sv-SE/package.json
+++ b/locales/sv-SE/package.json
@@ -67,9 +67,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/th-TH/package.json
+++ b/locales/th-TH/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-th-th",
   "version": "1.1.37",
   "private": false,
-  "description": "Thai / \u0e44\u0e17\u0e22 locale/translation for Sanity Studio",
+  "description": "Thai / ไทย locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",

--- a/locales/th-TH/package.json
+++ b/locales/th-TH/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-th-th",
   "version": "1.1.37",
   "private": false,
-  "description": "Thai / ไทย locale/translation for Sanity Studio",
+  "description": "Thai / \u0e44\u0e17\u0e22 locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",
@@ -50,9 +50,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/tr-TR/package.json
+++ b/locales/tr-TR/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-tr-tr",
   "version": "1.2.37",
   "private": false,
-  "description": "Turkish / Türkçe locale/translation for Sanity Studio",
+  "description": "Turkish / T\u00fcrk\u00e7e locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/tr-TR/package.json
+++ b/locales/tr-TR/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-tr-tr",
   "version": "1.2.37",
   "private": false,
-  "description": "Turkish / T\u00fcrk\u00e7e locale/translation for Sanity Studio",
+  "description": "Turkish / Türkçe locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",

--- a/locales/uk-UA/package.json
+++ b/locales/uk-UA/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-uk-ua",
   "version": "1.1.36",
   "private": false,
-  "description": "Ukrainian / \u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430 locale/translation for Sanity Studio",
+  "description": "Ukrainian / Українська locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",

--- a/locales/uk-UA/package.json
+++ b/locales/uk-UA/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-uk-ua",
   "version": "1.1.36",
   "private": false,
-  "description": "Ukrainian / Українська locale/translation for Sanity Studio",
+  "description": "Ukrainian / \u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430 locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/vi-VN/package.json
+++ b/locales/vi-VN/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-vi-vn",
   "version": "1.1.38",
   "private": false,
-  "description": "Vietnamese / Tiếng Việt locale/translation for Sanity Studio",
+  "description": "Vietnamese / Ti\u1ebfng Vi\u1ec7t locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/vi-VN/package.json
+++ b/locales/vi-VN/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-vi-vn",
   "version": "1.1.38",
   "private": false,
-  "description": "Vietnamese / Ti\u1ebfng Vi\u1ec7t locale/translation for Sanity Studio",
+  "description": "Vietnamese / Tiếng Việt locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",

--- a/locales/zh-Hans/package.json
+++ b/locales/zh-Hans/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-zh-hans",
   "version": "2.1.38",
   "private": false,
-  "description": "Chinese (Simplified) / 简体中文 locale/translation for Sanity Studio",
+  "description": "Chinese (Simplified) / \u7b80\u4f53\u4e2d\u6587 locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",
@@ -50,9 +50,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/locales/zh-Hans/package.json
+++ b/locales/zh-Hans/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-zh-hans",
   "version": "2.1.38",
   "private": false,
-  "description": "Chinese (Simplified) / \u7b80\u4f53\u4e2d\u6587 locale/translation for Sanity Studio",
+  "description": "Chinese (Simplified) / 简体中文 locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",

--- a/locales/zh-Hant/package.json
+++ b/locales/zh-Hant/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-zh-hant",
   "version": "2.2.38",
   "private": false,
-  "description": "Chinese (Traditional) / \u7e41\u9ad4\u4e2d\u6587 locale/translation for Sanity Studio",
+  "description": "Chinese (Traditional) / 繁體中文 locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",

--- a/locales/zh-Hant/package.json
+++ b/locales/zh-Hant/package.json
@@ -2,7 +2,7 @@
   "name": "@sanity/locale-zh-hant",
   "version": "2.2.38",
   "private": false,
-  "description": "Chinese (Traditional) / 繁體中文 locale/translation for Sanity Studio",
+  "description": "Chinese (Traditional) / \u7e41\u9ad4\u4e2d\u6587 locale/translation for Sanity Studio",
   "keywords": [
     "i18n",
     "locale",
@@ -55,9 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run pkg:build && npm run pkg:check",
-    "pkg:build": "pkg build --strict",
-    "pkg:check": "pkg check --strict",
+    "build": "pkg build --strict --check",
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {

--- a/src/api/builders/buildPackageJson.ts
+++ b/src/api/builders/buildPackageJson.ts
@@ -52,10 +52,8 @@ export async function buildPackageJson(locale: Locale): Promise<string> {
     },
     sideEffects: false,
     scripts: {
-      'build': 'npm run pkg:build && npm run pkg:check',
-      'pkg:build': 'pkg build --strict',
-      'pkg:check': 'pkg check --strict',
-      'prepublishOnly': 'pnpm build',
+      build: 'pkg build --strict --check',
+      prepublishOnly: 'pnpm build',
     },
     keywords: ['sanity', 'i18n', 'locale', 'localization', locale.id],
     files: ['dist'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Simplify locale package `build` scripts to use `pkg build --strict --check` instead of chaining separate `pkg:build` / `pkg:check` scripts.

## Changes

- Update `buildPackageJson` so newly reconciled locales get the simplified script
- Update all existing `locales/*/package.json` scripts accordingly
- Remove the now-unused `pkg:build` and `pkg:check` script entries

This matches `@sanity/pkg-utils` support for `--check` (`pkg build && pkg check` in one command).

Non-ASCII `description` fields were left unchanged (an earlier accidental `\uXXXX` escaping pass was reverted).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-766cc7eb-5f67-4c9e-9841-05cc2dcd3819?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-766cc7eb-5f67-4c9e-9841-05cc2dcd3819&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

