### PR TITLE
ci: run self-hosted Renovate via GitHub Actions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,68 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 */2 * * *' # Every 2 hours
+  pull_request:
+    types: [closed]
+    branches: [main]
+  issues:
+    types: [edited]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    # Filter out noise: only run for schedule, manual dispatch, merged Renovate PRs,
+    # and human-edited issues (not bot updates to the Dependency Dashboard).
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'renovate/')) ||
+      (github.event_name == 'issues' && github.event.sender.type != 'Bot')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v3 # zizmor: ignore[github-app]
+        id: app-token
+        with:
+          client-id: ${{ vars.ECOSPARK_CLIENT_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Generate Renovate runner config
+        id: config
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          CONFIG_FILE="$GITHUB_WORKSPACE/.renovate-runner-config.json5"
+
+          cat > "$CONFIG_FILE" <<'EOF'
+          {
+            $schema: "https://docs.renovatebot.com/renovate-schema.json",
+            onboarding: false,
+            requireConfig: "optional",
+          EOF
+
+          echo "  repositories: [\"$REPOSITORY\"]," >> "$CONFIG_FILE"
+          echo '}' >> "$CONFIG_FILE"
+
+          echo "Generated config:"
+          cat "$CONFIG_FILE"
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@e09d604f8f803bb527bd8321ed5be06c460b8682 # v46.2.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          configurationFile: .renovate-runner-config.json5
+        env:
+          GITHUB_COM_TOKEN: ${{ github.token }}
+          NODE_OPTIONS: '--max-old-space-size=4096'
+          LOG_LEVEL: debug


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the same self-hosted Renovate GitHub Actions runner used in [sanity-io/plugins](https://github.com/sanity-io/plugins/blob/main/.github/workflows/renovate.yml).

## What changed

New `.github/workflows/renovate.yml`:

- Runs every 2 hours, on `workflow_dispatch`, after merged `renovate/*` PRs, and when a human edits the Dependency Dashboard issue
- Authenticates with the Ecospark GitHub App (`vars.ECOSPARK_CLIENT_ID` + `secrets.ECOSPARK_APP_PRIVATE_KEY`), same as the other workflows in this repo
- Pins `renovatebot/github-action` to v46.2.2 (`e09d604f…`)
- Generates a one-shot runner config (`onboarding: false`, `requireConfig: optional`, this repository only)

Repository Renovate policy in `.github/renovate.json` is unchanged (schedules, Sanity grouping, peerDependency handling, monthly lockfile maintenance).

## Follow-up after merge

Disable the hosted Mend Renovate GitHub App on this repository so it does not compete with the Actions runner. Dependency PRs will then come from `squiggler-app[bot]` instead of `renovate[bot]`. The existing changesets-from-conventional-commits workflow already allows both identities.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0d0f544-a854-46d5-b4c1-efa2c54e41b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0d0f544-a854-46d5-b4c1-efa2c54e41b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

