### PR TITLE
Pin npm 11 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,9 @@ jobs:
           cache: pnpm
           check-latest: true
           node-version: lts/*
+      # Pin npm 11: npm 12's array-wrapped `pnpm info --json` breaks @changesets/cli 3.0.1 (changesets/changesets#2274). Trusted publishing needs npm >= 11.5.1.
       - name: Update npm to use trusted publishing (OIDC)
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - run: pnpm install
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`npm install -g npm@latest` now installs npm 12. Combined with pnpm 10 `pnpm info --json` pass-through, `@changesets/cli@3.0.1` does not unwrap npm 12's array-wrapped output and `changeset publish` crashes:

`TypeError: Cannot read properties of undefined (reading 'includes')` at `getPublishPlan.mjs:613`

Same failure: [changesets/changesets#2274](https://github.com/changesets/changesets/issues/2274), confirmed on [sanity-io/visual-editing](https://github.com/sanity-io/visual-editing) run 33517457076.

Pin `npm@11` so trusted publishing still works (OIDC needs npm >= 11.5.1). No other workflow changes. No `@changesets/*` bump.

## Verification
- Diff is the pin plus a one-line comment. Git user, `GITHUB_TOKEN`, turbo, and OIDC are unchanged.
- Isolated `npm@11` installs **11.19.1** (>= 11.5.1).
- `npm info --json` for `@sanity/locale-de-de`: npm 11 returns an object; npm 12 returns a one-element array.
- Replaying `@changesets/cli@3.0.1`'s pnpm `parseInfoResult` on that npm 12 output throws `TypeError: Cannot read properties of undefined (reading 'includes')`. The same parser accepts npm 11 output.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e79084fd-73a1-431e-ad00-8f3ba16880ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e79084fd-73a1-431e-ad00-8f3ba16880ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

